### PR TITLE
Handle two ring lenses

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BeamletOptics"
 uuid = "c387492b-ffec-4e51-9a46-bd230226031c"
 authors = ["Hugo Uittenbosch <hugo.uittenbosch@dlr.de>, Oliver Kliebisch <oliver.kliebisch@dlr.de> and Thomas Dekorsy <thomas.dekorsy@dlr.de>"]
-version = "0.8.2"
+version = "0.8.3"
 
 
 [deps]

--- a/src/OpticalComponents/Lenses.jl
+++ b/src/OpticalComponents/Lenses.jl
@@ -184,15 +184,12 @@ function Lens(
 
     # Initialize remaining cylindrical section length.
     l0 = center_thickness
-    @info l0
     # Front Surface
     front = sdf(front_surface, ForwardOrientation())
     l0 -= isnothing(front) ? zero(l0) : thickness(front)
-    @info l0
     # Back Surface
     back = sdf(back_surface, BackwardOrientation())
     l0 -= isnothing(back) ? zero(l0) : thickness(back)
-    @info l0
     # Use MeniscusLensSDF if cylinder length is non-positive
     if l0 ≤ 0
         if sign(radius(front_surface)) == sign(radius(back_surface))
@@ -221,7 +218,7 @@ function Lens(
             mid += back
         end
         shape = mid
-        @info l0
+
         d_front = diameter(front_surface)
         d_back = diameter(back_surface)
         d_min = min(d_front, d_back)

--- a/src/OpticalComponents/Lenses.jl
+++ b/src/OpticalComponents/Lenses.jl
@@ -224,21 +224,55 @@ function Lens(
 
         # Add mechanical ring if md_mid > d_mid
         if md_mid > d_mid
-            ring_thickness = thickness(mid)
-            ring_center = position(mid)[2] + ring_thickness / 2
-            if front !== nothing
-                s = edge_sag(front_surface, front)
-                ring_thickness -= s
-                ring_center += s / 2
+            if diameter(back_surface) > diameter(front_surface)
+                # add ring around section up to back surface
+                ring_thickness = l0 + thickness(front)
+                ring_center = position(mid)[2] + ring_thickness / 2
+                if front !== nothing
+                    s = edge_sag(front_surface, front)
+                    ring_thickness -= s
+                    ring_center += s / 2
+                end
+                ring = RingSDF(diameter(front_surface)/2, (diameter(back_surface) - diameter(front_surface)) / 2, ring_thickness)
+                translate3d!(ring, [0, ring_center, 0])
+                shape += ring
+
+                if md_mid > diameter(back_surface)
+                    # add second ring around the outer perimeter defined by diameter(back_surface)
+                    ring_thickness = thickness(mid)
+                    ring_center = position(mid)[2] + ring_thickness / 2
+                    if front !== nothing
+                        s = edge_sag(front_surface, front)
+                        ring_thickness -= s
+                        ring_center += s / 2
+                    end
+                    if back !== nothing
+                        s = edge_sag(back_surface, back)
+                        ring_thickness += s
+                        ring_center += s / 2
+                    end
+                    ring = RingSDF(diameter(back_surface) / 2, (md_mid - diameter(back_surface)) / 2, ring_thickness)
+                    translate3d!(ring, [0, ring_center, 0])
+                    shape += ring
+                end
+            else
+                # add one outer ring
+                ring_thickness = thickness(mid)
+                ring_center = position(mid)[2] + ring_thickness / 2
+                if front !== nothing
+                    s = edge_sag(front_surface, front)
+                    ring_thickness -= s
+                    ring_center += s / 2
+                end
+                if back !== nothing
+                    s = edge_sag(back_surface, back)
+                    ring_thickness += s
+                    ring_center += s / 2
+                end
+                ring = RingSDF(d_mid / 2, (md_mid - d_mid) / 2, ring_thickness)
+                translate3d!(ring, [0, ring_center, 0])
+                shape += ring
             end
-            if back !== nothing
-                s = edge_sag(back_surface, back)
-                ring_thickness += s
-                ring_center += s / 2
-            end
-            ring = RingSDF(d_mid / 2, (md_mid - d_mid) / 2, ring_thickness)
-            translate3d!(ring, [0, ring_center, 0])
-            shape += ring
         elseif md_mid < d_mid
             @warn "Mechanical diameter is less than clear aperture; parameter md has been ignored."
         end

--- a/src/SDFs/AsphericalLensSDF.jl
+++ b/src/SDFs/AsphericalLensSDF.jl
@@ -27,7 +27,8 @@ mutable struct ConvexAsphericalSurfaceSDF{T} <: AbstractAsphericalSurfaceSDF{T}
 end
 
 function thickness(s::ConvexAsphericalSurfaceSDF)
-    abs(aspheric_equation(s.diameter / 2, 1 / s.radius, s.conic_constant, s.coefficients))
+    sag = aspheric_equation(s.diameter / 2, 1 / s.radius, s.conic_constant, s.coefficients)
+    return s.max_sag[1] > 0 && sag < 0 ? s.max_sag[1] : abs(sag)
 end
 
 # Constructor for ConvexAsphericalSurfaceSDF

--- a/src/SDFs/SphericalLensSDF.jl
+++ b/src/SDFs/SphericalLensSDF.jl
@@ -465,7 +465,7 @@ end
 
 mechanical_diameter(s::SphericalSurface) = s.mechanical_diameter
 
-edge_sag(::SphericalSurface, sd::AbstractSphericalSurfaceSDF) = abs(sag(sd))
+edge_sag(::SphericalSurface, sd::AbstractSphericalSurfaceSDF) = sag(sd)
 
 function sdf(s::SphericalSurface, ot::AbstractOrientationType)
     isinf(radius(s)) && return nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1316,6 +1316,39 @@ end
 
         # test lens thickness
         @test BMO.thickness(lens) ≈ l
+
+        # test ring generation
+        NBK7 = DiscreteRefractiveIndex([532e-9, 1064e-9], [1.5195, 1.5066])
+        mm = 1e-3
+
+        s1 = Lens(
+            SphericalSurface(38.184mm, 2*1.840mm, 2*2.380mm),
+            SphericalSurface(3.467mm, 2*2.060mm, 2*2.380mm),
+            0.5mm,
+            NBK7
+        )
+
+        @test 2*s1.shape.sdfs[5].hthickness ≈ 0.001134 atol=1e-6
+
+        s2 = Lens(
+            SphericalSurface(3.467mm, 2*2.060mm, 2*2.380mm),
+            SphericalSurface(-5.020mm, 2*2.380mm, 2*2.380mm),
+            2.5mm,
+            NBK7
+        )
+
+        @test 2*s2.shape.sdfs[4].hthickness ≈ 0.001221590 atol=1e-8
+
+        # doublet test case
+        s1 = SphericalSurface(7.744mm, 2*2.812mm, 2*3mm)
+        s2 = SphericalSurface(-3.642mm, 2*3mm)
+        s3 = SphericalSurface(-14.413mm, 2*2.812mm, 2*3mm)
+
+        dl21 = Lens(s1, s2, 3.4mm, NBK7)
+        dl22 = Lens(s2, s3, 1.0mm, NBK7)
+
+        @test 2*dl21.shape.sdfs[4].hthickness ≈ 0.001294398 atol=1e-6
+        @test 2*dl22.shape.sdfs[4].hthickness ≈ 0.000723025 atol=1e-6
     end
 end
 
@@ -1486,6 +1519,11 @@ end
             # test if the beam is correctly focussed
             @test f_pos[3]≈0 atol=1e-7
         end
+
+        # test rings
+        @test 2*L1.shape.sdfs[4].hthickness ≈ 0.00060839 atol=1e-6
+        @test 2*L2.shape.sdfs[4].hthickness ≈ 0.00057497 atol=1e-6
+        @test 2*L3.shape.sdfs[4].hthickness ≈ 0.00048395 atol=1e-6
     end
 end
 


### PR DESCRIPTION
This is a fix for https://github.com/StackEnjoyer/BeamletOptics.jl/issues/6

I have slightly modified the test code to include the working diameters.

```julia
using GLMakie, BeamletOptics

const BMO = BeamletOptics

NBK7 = DiscreteRefractiveIndex([532e-9, 1064e-9], [1.5195, 1.5066])

const mm = 1e-3

##
s1 = Lens(
    SphericalSurface(38.184mm, 2*1.840mm, 2*2.380mm),
    SphericalSurface(3.467mm, 2*2.060mm, 2*2.380mm),
    0.5mm,
    NBK7
)

s2 = Lens(
    SphericalSurface(3.467mm, 2*2.060mm, 2*2.380mm),
    SphericalSurface(-5.020mm, 2*2.380mm, 2*2.380mm),
    2.5mm,
    NBK7
)

translate3d!(s2, [0,BMO.thickness(s1) + 2mm,0])

fig = Figure()
ax = LScene(fig[1,1])
render_object!(ax, s1)
render_object!(ax, s2)

fig
```

<img width="725" alt="Bildschirmfoto 2025-04-03 um 20 36 27" src="https://github.com/user-attachments/assets/62197255-803f-4d77-b133-aa3fc5c1c93e" />


