### PR TITLE
Render keyword args

### DIFF
--- a/ext/BeamletOpticsMakieExt.jl
+++ b/ext/BeamletOpticsMakieExt.jl
@@ -60,9 +60,9 @@ end
 
 render_sdf_mesh!(axis::_RenderEnv, vertices, faces; transparency = true) = mesh!(axis, vertices, faces, transparency=transparency)
 
-function render_dummy_mesh!(axis::_RenderEnv, d::NonInteractableObject; transparency = false)
+function render_dummy_mesh!(axis::_RenderEnv, d::NonInteractableObject; transparency = false, kwargs...)
     mesh = d.shape
-    mesh!(axis, vertices(mesh), faces(mesh); transparency, color = :grey)
+    mesh!(axis, vertices(mesh), faces(mesh); transparency, color = :grey, kwargs...)
     return nothing
 end
 

--- a/src/OpticalComponents/NonInteractable.jl
+++ b/src/OpticalComponents/NonInteractable.jl
@@ -21,6 +21,6 @@ interact3d(::AbstractSystem, ::NonInteractableObject, ::AbstractBeam, ::Abstract
 
 MeshDummy(loadpath::String) = NonInteractableObject(Mesh(load(loadpath)))
 
-render_object!(axis, dummy::NonInteractableObject) = render_dummy_mesh!(axis, dummy)
+render_object!(axis, dummy::NonInteractableObject; kwargs...) = render_dummy_mesh!(axis, dummy; kwargs...)
 
-render_dummy_mesh!(::Any, ::NonInteractableObject) = nothing
+render_dummy_mesh!(::Any, ::NonInteractableObject; kwargs...) = nothing


### PR DESCRIPTION
This PR intends the following changes

- [ ] let users pass through kwargs through the `render_xyz` method to the underlying `Makie` functions
- [ ] introduce a single `render` function that is dispatched by all `AbstractObjects`, `AbstractRays`, etc.
    - this will be a breaking change...

This will allow more flexibility when creating plots.

An example is attached below:

![1234](https://github.com/user-attachments/assets/97c47279-1cda-426d-8c69-83fa9f66db43)

